### PR TITLE
[Proposal] Change zstd compression levels to match zstd levels exactly

### DIFF
--- a/fs/bcachefs/compress.c
+++ b/fs/bcachefs/compress.c
@@ -349,11 +349,9 @@ static int attempt_compress(struct bch_fs *c,
 	}
 	case BCH_COMPRESSION_TYPE_zstd: {
 		/*
-		 * rescale:
-		 * zstd max compression level is 22, our max level is 15
+		 * only use zstd compression levels 1-15
 		 */
-		unsigned level = min((compression.level * 3) / 2, zstd_max_clevel());
-		ZSTD_parameters params = zstd_get_params(level, c->opts.encoded_extent_max);
+		ZSTD_parameters params = zstd_get_params(compression.level, c->opts.encoded_extent_max);
 		ZSTD_CCtx *ctx = zstd_init_cctx(workspace, c->zstd_workspace_size);
 
 		/*


### PR DESCRIPTION
I noticed that bcachefs is mapping its compression levels (1-15) to zstd's compression levels (1-22) using `floor(level * 3 / 2)`. This PR proposes to change this mapping to be direct, and use only zstd compression levels 1-15. My reasoning for this change is as follows:

 - This mapping, requiring integer truncation, results in an uneven mapping of compression levels. Increasing the bcachefs compression level by one will increase the underlying compression level by either one or two depending on the starting level. Using a direct mapping of compression levels fixes this.
 - bcachefs uses a default compression level of 3, which seems to map to zstd's default compression level of 3. However, the remapping of compression levels means that a bcachefs compression level of 3 is actually a zstd compression level of 4, which is more than the default for zstd. Using a direct mapping will bring the default compression levels of bcachefs and zstd in line with each other.
 - Referring to zstd's compression levels as being "from 1 to 22" is a bit disingenuous, as it ignores the seven "negative" compression levels (accessed in the command line tool with `--fast=N`). Having bcachefs ignore some of the higher compression levels is not a significant deal, considering that it's already ignoring some of the lower compression levels.
 - Similarly, the command-line tool `zstd`, the compression levels 20-22 are not accessible without an additional command-line argument (`--ultra`) to tell it you really want to use compression levels that high. Counting those higher compression levels as being equivalent to the others can be misleading, and excluding them shouldn't be a significant change.
 - btrfs's zstd compression also has 15 compression levels, but they map their compression levels to zstd's compression levels 1-15 directly. Changing bcachefs's compression level mapping to match btrfs means that [existing benchmarks for btrfs compression levels](https://docs.google.com/spreadsheets/d/1x9-3OQF4ev1fOCrYuYWt1QmxYRmPilw_nLik5H_2_qA/) will be more accurate for bcachefs.

If keeping access to these higher compression levels is a priority, then perhaps a non-linear mapping would be better suited. One option would be to map levels 1-8 (or 1-7) directly to the zstd levels, and then have the higher levels skip every other compression level (clamped to <=22). This would provide a compromise between providing more low compression levels and maintaining access to the max compression level, all while addressing the above issues. Let me know if you'd rather this solution, and I can update the PR with it.